### PR TITLE
Implement mdb-locales patch

### DIFF
--- a/configure
+++ b/configure
@@ -698,6 +698,7 @@ BISON
 MKDIR_P
 LN_S
 TAR
+USE_MDBLOCALES
 install_bin
 INSTALL_DATA
 INSTALL_SCRIPT
@@ -943,6 +944,7 @@ with_rt
 with_libcurl
 with_apr_config
 with_gnu_ld
+with_mdblocales
 with_ssl
 with_openssl
 enable_openssl_redirect
@@ -1690,6 +1692,7 @@ Optional Packages:
   --without-libcurl       do not use libcurl
   --with-apr-config=PATH  path to apr-1-config utility
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
+  --without-mdblocales    build without MDB locales
   --with-ssl=LIB          use LIB for SSL/TLS support (openssl)
   --with-openssl          obsolete spelling of --with-ssl=openssl
 
@@ -2903,7 +2906,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 PG_PACKAGE_VERSION=14.4
-
 
 
 
@@ -12124,6 +12126,38 @@ case $INSTALL in
 esac
 
 
+#
+# MDB locales
+#
+
+
+
+
+# Check whether --with-mdblocales was given.
+if test "${with_mdblocales+set}" = set; then :
+  withval=$with_mdblocales;
+  case $withval in
+    yes)
+
+$as_echo "#define USE_MDBLOCALES 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --with-mdblocales option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  with_mdblocales=no
+
+fi
+
+
+
+
 if test -z "$TAR"; then
   for ac_prog in tar
 do
@@ -12759,6 +12793,56 @@ python_additional_libs=`${PYTHON} -c "import sysconfig; print(' '.join(filter(No
 $as_echo "${python_libspec} ${python_additional_libs}" >&6; }
 
 
+
+fi
+
+if test "$with_mdblocales" = yes; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for mdb_setlocale in -lmdblocales" >&5
+$as_echo_n "checking for mdb_setlocale in -lmdblocales... " >&6; }
+if ${ac_cv_lib_mdblocales_mdb_setlocale+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lmdblocales  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char mdb_setlocale ();
+int
+main ()
+{
+return mdb_setlocale ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_mdblocales_mdb_setlocale=yes
+else
+  ac_cv_lib_mdblocales_mdb_setlocale=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mdblocales_mdb_setlocale" >&5
+$as_echo "$ac_cv_lib_mdblocales_mdb_setlocale" >&6; }
+if test "x$ac_cv_lib_mdblocales_mdb_setlocale" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBMDBLOCALES 1
+_ACEOF
+
+  LIBS="-lmdblocales $LIBS"
+
+else
+  as_fn_error $? "mdblocales library not found" "$LINENO" 5
+fi
 
 fi
 
@@ -16980,6 +17064,17 @@ else
 fi
 
 done
+
+fi
+
+if test "$with_mdblocales" = yes; then
+  ac_fn_c_check_header_mongrel "$LINENO" "mdblocales.h" "ac_cv_header_mdblocales_h" "$ac_includes_default"
+if test "x$ac_cv_header_mdblocales_h" = xyes; then :
+
+else
+  as_fn_error $? "mdblocales header not found." "$LINENO" 5
+fi
+
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1448,6 +1448,14 @@ case $INSTALL in
 esac
 AC_SUBST(install_bin)
 
+#
+# MDB locales
+#
+
+PGAC_ARG_BOOL(with, mdblocales, yes, [build without MDB locales],
+              [AC_DEFINE([USE_MDBLOCALES], 1, [Define to 1 to build with MDB locales. (--with-mdblocales)])])
+AC_SUBST(USE_MDBLOCALES)
+
 PGAC_PATH_PROGS(TAR, tar)
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
@@ -1604,6 +1612,11 @@ if test "$with_zlib" = yes; then
 If you have zlib already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.
 Use --without-zlib to disable zlib support.])])
+fi
+
+if test "$with_mdblocales" = yes; then
+  AC_CHECK_LIB(mdblocales, mdb_setlocale, [],
+               [AC_MSG_ERROR([mdblocales library not found])])
 fi
 
 if test "$enable_external_fts" = yes; then
@@ -1983,6 +1996,10 @@ fi
 
 if test "$with_lz4" = yes; then
   AC_CHECK_HEADERS(lz4.h, [], [AC_MSG_ERROR([lz4.h header file is required for LZ4])])
+fi
+
+if test "$with_mdblocales" = yes; then
+  AC_CHECK_HEADER(mdblocales.h, [], [AC_MSG_ERROR([mdblocales header not found.])])
 fi
 
 if test "$with_gssapi" = yes ; then

--- a/contrib/pax_storage/src/cpp/storage/oper/pax_oper.cc
+++ b/contrib/pax_storage/src/cpp/storage/oper/pax_oper.cc
@@ -25,6 +25,7 @@
  *-------------------------------------------------------------------------
  */
 
+#include "common/mdb_locale.h"
 #include "storage/oper/pax_oper.h"
 
 #include "comm/cbdb_wrappers.h"
@@ -588,9 +589,9 @@ static inline bool LocaleIsC(Oid collation) {
       return (bool)result;
     }
 
-    localeptr = setlocale(LC_COLLATE, NULL);
+    localeptr = SETLOCALE(LC_COLLATE, NULL);
     CBDB_CHECK(localeptr, cbdb::CException::ExType::kExTypeCError,
-               fmt("Invalid locale, fail to `setlocale`, errno: %d", errno));
+               fmt("Invalid locale, fail to `SETLOCALE`, errno: %d", errno));
 
     if (strcmp(localeptr, "C") == 0 ||  // cut line
         strcmp(localeptr, "POSIX") == 0) {

--- a/gpcontrib/orafce/others.c
+++ b/gpcontrib/orafce/others.c
@@ -45,6 +45,7 @@
 #include "utils/uuid.h"
 #include "orafce.h"
 #include "builtins.h"
+#include "common/mdb_locale.h"
 
 /*
  * Source code for nlssort is taken from postgresql-nls-string
@@ -322,7 +323,7 @@ _nls_run_strxfrm(text *string, text *locale)
 	 */
 	if (!lc_collate_cache)
 	{
-		if ((lc_collate_cache = setlocale(LC_COLLATE, NULL)))
+		if ((lc_collate_cache = SETLOCALE(LC_COLLATE, NULL)))
 			/* Make a copy of the locale name string. */
 #ifdef _MSC_VER
 			lc_collate_cache = _strdup(lc_collate_cache);
@@ -364,7 +365,7 @@ _nls_run_strxfrm(text *string, text *locale)
 			 * If setlocale failed, we know the default stayed the same,
 			 * co we can safely elog.
 			 */
-			if (!setlocale(LC_COLLATE, locale_str))
+			if (!SETLOCALE(LC_COLLATE, locale_str))
 				elog(ERROR, "failed to set the requested LC_COLLATE value [%s]", locale_str);
 
 			changed_locale = true;
@@ -409,7 +410,7 @@ _nls_run_strxfrm(text *string, text *locale)
 			/*
 			 * Set original locale
 			 */
-			if (!setlocale(LC_COLLATE, lc_collate_cache))
+			if (!SETLOCALE(LC_COLLATE, lc_collate_cache))
 				elog(FATAL, "failed to set back the default LC_COLLATE value [%s]", lc_collate_cache);
 		}
 
@@ -422,7 +423,7 @@ _nls_run_strxfrm(text *string, text *locale)
 		/*
 		 * Set original locale
 		 */
-		if (!setlocale(LC_COLLATE, lc_collate_cache))
+		if (!SETLOCALE(LC_COLLATE, lc_collate_cache))
 			elog(FATAL, "failed to set back the default LC_COLLATE value [%s]", lc_collate_cache);
 		pfree(locale_str);
 	}

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/string/CWStringTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/string/CWStringTest.cpp
@@ -12,6 +12,7 @@
 #include "unittest/gpos/string/CWStringTest.h"
 
 #include <locale.h>
+#include "common/mdb_locale.h"
 
 #include "gpos/base.h"
 #include "gpos/error/CAutoTrace.h"
@@ -177,18 +178,18 @@ CWStringTest::EresUnittest_AppendFormatInvalidLocale()
 	CWStringDynamic *expected =
 		GPOS_NEW(mp) CWStringDynamic(mp, GPOS_WSZ_LIT("UNKNOWN"));
 
-	CHAR *oldLocale = setlocale(LC_CTYPE, nullptr);
+	CHAR *oldLocale = SETLOCALE(LC_CTYPE, nullptr);
 	CWStringDynamic *pstr1 = GPOS_NEW(mp) CWStringDynamic(mp);
 
 	GPOS_RESULT eres = GPOS_OK;
 
-	setlocale(LC_CTYPE, "C");
+	SETLOCALE(LC_CTYPE, "C");
 	pstr1->AppendFormat(GPOS_WSZ_LIT("%s"), (CHAR *) "ÃË", 123);
 
 	pstr1->Equals(expected);
 
 	// cleanup
-	setlocale(LC_CTYPE, oldLocale);
+	SETLOCALE(LC_CTYPE, oldLocale);
 	GPOS_DELETE(pstr1);
 	GPOS_DELETE(expected);
 

--- a/src/backend/utils/adt/Makefile
+++ b/src/backend/utils/adt/Makefile
@@ -117,7 +117,8 @@ OBJS = \
 	windowfuncs.o \
 	xid.o \
 	xid8funcs.o \
-	xml.o
+	xml.o \
+	mdb.o
 
 jsonpath_scan.c: FLEXFLAGS = -CF -p -p
 jsonpath_scan.c: FLEX_NO_BACKUP=yes

--- a/src/backend/utils/adt/mdb.c
+++ b/src/backend/utils/adt/mdb.c
@@ -1,0 +1,37 @@
+/*-------------------------------------------------------------------------
+ *
+ * mdb.c
+ *	  mdb routines
+ *
+ * Portions Copyright (c) 1996-2022, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/adt/mdb.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/fmgrprotos.h"
+
+/*
+ * mdb_admin_enabled
+ *		Check that mdb locale patch is enabled
+ */
+Datum
+mdb_locale_enabled(PG_FUNCTION_ARGS)
+{
+	bool res;
+
+#if USE_MDBLOCALES
+	res = true;
+#else
+	res = false;
+#endif
+
+	PG_RETURN_BOOL(res);
+}

--- a/src/backend/utils/adt/pg_locale.c
+++ b/src/backend/utils/adt/pg_locale.c
@@ -66,6 +66,7 @@
 #include "utils/memutils.h"
 #include "utils/pg_locale.h"
 #include "utils/syscache.h"
+#include "common/mdb_locale.h"
 
 #ifdef USE_ICU
 #include <unicode/ucnv.h>
@@ -147,7 +148,7 @@ pg_perm_setlocale(int category, const char *locale)
 	const char *envvar;
 
 #ifndef WIN32
-	result = setlocale(category, locale);
+	result = SETLOCALE(category, locale);
 #else
 
 	/*
@@ -165,7 +166,7 @@ pg_perm_setlocale(int category, const char *locale)
 	}
 	else
 #endif
-		result = setlocale(category, locale);
+		result = SETLOCALE(category, locale);
 #endif							/* WIN32 */
 
 	if (result == NULL)
@@ -252,7 +253,7 @@ check_locale(int category, const char *locale, char **canonname)
 	if (canonname)
 		*canonname = NULL;		/* in case of failure */
 
-	save = setlocale(category, NULL);
+	save = SETLOCALE(category, NULL);
 	if (!save)
 		return false;			/* won't happen, we hope */
 
@@ -260,14 +261,14 @@ check_locale(int category, const char *locale, char **canonname)
 	save = pstrdup(save);
 
 	/* set the locale with setlocale, to see if it accepts it. */
-	res = setlocale(category, locale);
+	res = SETLOCALE(category, locale);
 
 	/* save canonical name if requested. */
 	if (res && canonname)
 		*canonname = pstrdup(res);
 
 	/* restore old value. */
-	if (!setlocale(category, save))
+	if (!SETLOCALE(category, save))
 		elog(WARNING, "failed to restore old locale \"%s\"", save);
 	pfree(save);
 
@@ -501,12 +502,12 @@ PGLC_localeconv(void)
 	memset(&worklconv, 0, sizeof(worklconv));
 
 	/* Save prevailing values of monetary and numeric locales */
-	save_lc_monetary = setlocale(LC_MONETARY, NULL);
+	save_lc_monetary = SETLOCALE(LC_MONETARY, NULL);
 	if (!save_lc_monetary)
 		elog(ERROR, "setlocale(NULL) failed");
 	save_lc_monetary = pstrdup(save_lc_monetary);
 
-	save_lc_numeric = setlocale(LC_NUMERIC, NULL);
+	save_lc_numeric = SETLOCALE(LC_NUMERIC, NULL);
 	if (!save_lc_numeric)
 		elog(ERROR, "setlocale(NULL) failed");
 	save_lc_numeric = pstrdup(save_lc_numeric);
@@ -528,7 +529,7 @@ PGLC_localeconv(void)
 	 */
 
 	/* Save prevailing value of ctype locale */
-	save_lc_ctype = setlocale(LC_CTYPE, NULL);
+	save_lc_ctype = SETLOCALE(LC_CTYPE, NULL);
 	if (!save_lc_ctype)
 		elog(ERROR, "setlocale(NULL) failed");
 	save_lc_ctype = pstrdup(save_lc_ctype);
@@ -536,11 +537,11 @@ PGLC_localeconv(void)
 	/* Here begins the critical section where we must not throw error */
 
 	/* use numeric to set the ctype */
-	setlocale(LC_CTYPE, locale_numeric);
+	SETLOCALE(LC_CTYPE, locale_numeric);
 #endif
 
 	/* Get formatting information for numeric */
-	setlocale(LC_NUMERIC, locale_numeric);
+	SETLOCALE(LC_NUMERIC, locale_numeric);
 	extlconv = localeconv();
 
 	/* Must copy data now in case setlocale() overwrites it */
@@ -550,11 +551,11 @@ PGLC_localeconv(void)
 
 #ifdef WIN32
 	/* use monetary to set the ctype */
-	setlocale(LC_CTYPE, locale_monetary);
+	SETLOCALE(LC_CTYPE, locale_monetary);
 #endif
 
 	/* Get formatting information for monetary */
-	setlocale(LC_MONETARY, locale_monetary);
+	SETLOCALE(LC_MONETARY, locale_monetary);
 	extlconv = localeconv();
 
 	/* Must copy data now in case setlocale() overwrites it */
@@ -584,12 +585,12 @@ PGLC_localeconv(void)
 	 * should fail.
 	 */
 #ifdef WIN32
-	if (!setlocale(LC_CTYPE, save_lc_ctype))
+	if (!SETLOCALE(LC_CTYPE, save_lc_ctype))
 		elog(FATAL, "failed to restore LC_CTYPE to \"%s\"", save_lc_ctype);
 #endif
-	if (!setlocale(LC_MONETARY, save_lc_monetary))
+	if (!SETLOCALE(LC_MONETARY, save_lc_monetary))
 		elog(FATAL, "failed to restore LC_MONETARY to \"%s\"", save_lc_monetary);
-	if (!setlocale(LC_NUMERIC, save_lc_numeric))
+	if (!SETLOCALE(LC_NUMERIC, save_lc_numeric))
 		elog(FATAL, "failed to restore LC_NUMERIC to \"%s\"", save_lc_numeric);
 
 	/*
@@ -773,7 +774,7 @@ cache_locale_time(void)
 	 */
 
 	/* Save prevailing value of time locale */
-	save_lc_time = setlocale(LC_TIME, NULL);
+	save_lc_time = SETLOCALE(LC_TIME, NULL);
 	if (!save_lc_time)
 		elog(ERROR, "setlocale(NULL) failed");
 	save_lc_time = pstrdup(save_lc_time);
@@ -788,16 +789,16 @@ cache_locale_time(void)
 	 */
 
 	/* Save prevailing value of ctype locale */
-	save_lc_ctype = setlocale(LC_CTYPE, NULL);
+	save_lc_ctype = SETLOCALE(LC_CTYPE, NULL);
 	if (!save_lc_ctype)
 		elog(ERROR, "setlocale(NULL) failed");
 	save_lc_ctype = pstrdup(save_lc_ctype);
 
 	/* use lc_time to set the ctype */
-	setlocale(LC_CTYPE, locale_time);
+	SETLOCALE(LC_CTYPE, locale_time);
 #endif
 
-	setlocale(LC_TIME, locale_time);
+	SETLOCALE(LC_TIME, locale_time);
 
 	/* We use times close to current time as data for strftime(). */
 	timenow = time(NULL);
@@ -846,10 +847,10 @@ cache_locale_time(void)
 	 * failure to do so is fatal.
 	 */
 #ifdef WIN32
-	if (!setlocale(LC_CTYPE, save_lc_ctype))
+	if (!SETLOCALE(LC_CTYPE, save_lc_ctype))
 		elog(FATAL, "failed to restore LC_CTYPE to \"%s\"", save_lc_ctype);
 #endif
-	if (!setlocale(LC_TIME, save_lc_time))
+	if (!SETLOCALE(LC_TIME, save_lc_time))
 		elog(FATAL, "failed to restore LC_TIME to \"%s\"", save_lc_time);
 
 	/*
@@ -1225,7 +1226,7 @@ check_strxfrm_bug(void)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYSTEM_ERROR),
 				 errmsg_internal("strxfrm(), in locale \"%s\", writes past the specified array length",
-								 setlocale(LC_COLLATE, NULL)),
+					SETLOCALE(LC_COLLATE, NULL)),
 				 errhint("Apply system library package updates.")));
 }
 
@@ -1339,7 +1340,7 @@ lc_collate_is_c(Oid collation)
 
 		if (result >= 0)
 			return (bool) result;
-		localeptr = setlocale(LC_COLLATE, NULL);
+		localeptr = SETLOCALE(LC_COLLATE, NULL);
 		if (!localeptr)
 			elog(ERROR, "invalid LC_COLLATE setting");
 
@@ -1389,7 +1390,7 @@ lc_ctype_is_c(Oid collation)
 
 		if (result >= 0)
 			return (bool) result;
-		localeptr = setlocale(LC_CTYPE, NULL);
+		localeptr = SETLOCALE(LC_CTYPE, NULL);
 		if (!localeptr)
 			elog(ERROR, "invalid LC_CTYPE setting");
 
@@ -1518,8 +1519,10 @@ pg_newlocale_from_collation(Oid collid)
 				/* Normal case where they're the same */
 				errno = 0;
 #ifndef WIN32
-				loc = newlocale(LC_COLLATE_MASK | LC_CTYPE_MASK, collcollate,
+
+				loc = NEWLOCALE(LC_COLLATE_MASK | LC_CTYPE_MASK, collcollate,
 								NULL);
+
 #else
 				loc = _create_locale(LC_ALL, collcollate);
 #endif
@@ -1533,11 +1536,11 @@ pg_newlocale_from_collation(Oid collid)
 				locale_t	loc1;
 
 				errno = 0;
-				loc1 = newlocale(LC_COLLATE_MASK, collcollate, NULL);
+				loc1 = NEWLOCALE(LC_COLLATE_MASK, collcollate, NULL);
 				if (!loc1)
 					report_newlocale_failure(collcollate);
 				errno = 0;
-				loc = newlocale(LC_CTYPE_MASK, collctype, loc1);
+				loc = NEWLOCALE(LC_CTYPE_MASK, collctype, loc1);
 				if (!loc)
 					report_newlocale_failure(collctype);
 #else
@@ -1680,12 +1683,16 @@ get_collation_actual_version(char collprovider, const char *collcollate)
 	{
 #if defined(__GLIBC__)
 		/* Use the glibc version because we don't have anything better. */
+#ifdef USE_MDBLOCALES
+		collversion = pstrdup(mdb_localesversion());
+#else
 		collversion = pstrdup(gnu_get_libc_version());
+#endif
 #elif defined(LC_VERSION_MASK)
 		locale_t	loc;
 
 		/* Look up FreeBSD collation version. */
-		loc = newlocale(LC_COLLATE, collcollate, NULL);
+		loc = NEWLOCALE(LC_COLLATE, collcollate, NULL);
 		if (loc)
 		{
 			collversion =

--- a/src/backend/utils/mb/mbutils.c
+++ b/src/backend/utils/mb/mbutils.c
@@ -40,6 +40,7 @@
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 #include "utils/syscache.h"
+#include "common/mdb_locale.h"
 
 /*
  * We maintain a simple linked list caching the fmgr lookup info for the
@@ -1308,7 +1309,7 @@ pg_bind_textdomain_codeset(const char *domainname)
 	int			new_msgenc;
 
 #ifndef WIN32
-	const char *ctype = setlocale(LC_CTYPE, NULL);
+	const char *ctype = SETLOCALE(LC_CTYPE, NULL);
 
 	if (pg_strcasecmp(ctype, "C") == 0 || pg_strcasecmp(ctype, "POSIX") == 0)
 #endif

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -75,6 +75,7 @@
 #include "getopt_long.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
+#include "common/mdb_locale.h"
 
 #include "catalog/catalog.h"
 
@@ -2274,12 +2275,13 @@ locale_date_order(const char *locale)
 
 	result = DATEORDER_MDY;		/* default */
 
-	save = setlocale(LC_TIME, NULL);
+	save = SETLOCALE(LC_TIME, NULL);
+
 	if (!save)
 		return result;
 	save = pg_strdup(save);
 
-	setlocale(LC_TIME, locale);
+	SETLOCALE(LC_TIME, locale);
 
 	memset(&testtime, 0, sizeof(testtime));
 	testtime.tm_mday = 22;
@@ -2288,7 +2290,7 @@ locale_date_order(const char *locale)
 
 	res = my_strftime(buf, sizeof(buf), "%x", &testtime);
 
-	setlocale(LC_TIME, save);
+	SETLOCALE(LC_TIME, save);
 	free(save);
 
 	if (res == 0)
@@ -2332,7 +2334,7 @@ check_locale_name(int category, const char *locale, char **canonname)
 	if (canonname)
 		*canonname = NULL;		/* in case of failure */
 
-	save = setlocale(category, NULL);
+	save = SETLOCALE(category, NULL);
 	if (!save)
 	{
 		pg_log_error("setlocale() failed");
@@ -2347,14 +2349,14 @@ check_locale_name(int category, const char *locale, char **canonname)
 		locale = "";
 
 	/* set the locale with setlocale, to see if it accepts it. */
-	res = setlocale(category, locale);
+	res = SETLOCALE(category, locale);
 
 	/* save canonical name if requested. */
 	if (res && canonname)
 		*canonname = pg_strdup(res);
 
 	/* restore old value. */
-	if (!setlocale(category, save))
+	if (!SETLOCALE(category, save))
 	{
 		pg_log_error("failed to restore old locale \"%s\"", save);
 		exit(1);

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -16,6 +16,8 @@
 #include "mb/pg_wchar.h"
 #include "pg_upgrade.h"
 #include "greenplum/pg_upgrade_greenplum.h"
+#include "common/mdb_locale.h"
+
 
 static void check_new_cluster_is_empty(void);
 static void check_databases_are_compatible(void);
@@ -1627,7 +1629,8 @@ get_canonical_locale_name(int category, const char *locale)
 	char	   *res;
 
 	/* get the current setting, so we can restore it. */
-	save = setlocale(category, NULL);
+
+	save = SETLOCALE(category, NULL);
 	if (!save)
 		pg_fatal("failed to get the current locale\n");
 
@@ -1635,7 +1638,7 @@ get_canonical_locale_name(int category, const char *locale)
 	save = (char *) pg_strdup(save);
 
 	/* set the locale with setlocale, to see if it accepts it. */
-	res = setlocale(category, locale);
+	res = SETLOCALE(category, locale);
 
 	if (!res)
 		pg_fatal("failed to get system locale name for \"%s\"\n", locale);
@@ -1643,7 +1646,7 @@ get_canonical_locale_name(int category, const char *locale)
 	res = pg_strdup(res);
 
 	/* restore old value. */
-	if (!setlocale(category, save))
+	if (!SETLOCALE(category, save))
 		pg_fatal("failed to restore old locale \"%s\"\n", save);
 
 	pg_free(save);

--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -24,6 +24,8 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include "common/mdb_locale.h"
+
 
 /* Inhibit mingw CRT's auto-globbing of command line arguments */
 #if defined(WIN32) && !defined(_MSC_VER)
@@ -443,7 +445,7 @@ set_pglocale_pgservice(const char *argv0, const char *app)
 	/* don't set LC_ALL in the backend */
 	if (strcmp(app, PG_TEXTDOMAIN("postgres")) != 0)
 	{
-		setlocale(LC_ALL, "");
+		SETLOCALE(LC_ALL, "");
 
 		/*
 		 * One could make a case for reproducing here PostmasterMain()'s test

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11754,7 +11754,9 @@
 #
 # GPDB ADDITIONS START HERE
 #
-
+{ oid => '16383', descr => 'contains',
+  proname => 'mdb_locale_enabled', prorettype => 'bool',
+  proargtypes => '', prosrc => 'mdb_locale_enabled' },
 { oid => '7178', descr => 'for use by pg_upgrade',
   proname => 'binary_upgrade_set_preassigned_oids', provolatile => 'v',
   proparallel => 'u', prorettype => 'void', proargtypes => '_oid',

--- a/src/include/common/mdb_locale.h
+++ b/src/include/common/mdb_locale.h
@@ -1,0 +1,41 @@
+/*-------------------------------------------------------------------------
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * mdb_locale.h
+ *	  Generic headers for custom MDB-locales patch.
+ *
+ * IDENTIFICATION
+ *		  src/include/common/mdb_locale.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PG_MDB_LOCALE_H
+#define PG_MDB_LOCALE_H
+
+#ifdef USE_MDBLOCALES
+#include <mdblocales.h>
+#define SETLOCALE(category, locale) mdb_setlocale(category, locale)
+#define NEWLOCALE(category, locale, base) mdb_newlocale(category, locale, base)
+#else
+#define SETLOCALE(category, locale) setlocale(category, locale)
+#define NEWLOCALE(category, locale, base) newlocale(category, locale, base)
+#endif
+
+#endif							/* PG_MDB_LOCALE_H */

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -389,6 +389,9 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
+/* Define to 1 if you have the `mdblocales' library (-lmdblocales). */
+#undef HAVE_LIBMDBLOCALES
+
 /* Define to 1 if you have the `numa' library (-lnuma). */
 #undef HAVE_LIBNUMA
 
@@ -1037,6 +1040,9 @@
 
 /* Define to 1 to build with LZ4 support. (--with-lz4) */
 #undef USE_LZ4
+
+/* Define to 1 to build with MDB locales. (--with-mdblocales) */
+#undef USE_MDBLOCALES
 
 /* Define to 1 to build with Mapreduce capabilities (--enable-mapreduce) */
 #undef USE_MAPREDUCE

--- a/src/interfaces/ecpg/ecpglib/connect.c
+++ b/src/interfaces/ecpg/ecpglib/connect.c
@@ -9,6 +9,7 @@
 #include "ecpglib_extern.h"
 #include "ecpgtype.h"
 #include "sqlca.h"
+#include "common/mdb_locale.h"
 
 #ifdef HAVE_USELOCALE
 locale_t	ecpg_clocale = (locale_t) 0;
@@ -517,7 +518,7 @@ ECPGconnect(int lineno, int c, const char *name, const char *user, const char *p
 #ifdef HAVE_USELOCALE
 	if (!ecpg_clocale)
 	{
-		ecpg_clocale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+		ecpg_clocale = NEWLOCALE(LC_NUMERIC_MASK, "C", (locale_t) 0);
 		if (!ecpg_clocale)
 		{
 #ifdef ENABLE_THREAD_SAFETY

--- a/src/interfaces/ecpg/ecpglib/descriptor.c
+++ b/src/interfaces/ecpg/ecpglib/descriptor.c
@@ -15,6 +15,8 @@
 #include "sql3types.h"
 #include "sqlca.h"
 #include "sqlda.h"
+#include "common/mdb_locale.h"
+
 
 static void descriptor_free(struct descriptor *desc);
 
@@ -500,8 +502,8 @@ ECPGget_desc(int lineno, const char *desc_name, int index,...)
 #ifdef HAVE__CONFIGTHREADLOCALE
 		stmt.oldthreadlocale = _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
 #endif
-		stmt.oldlocale = ecpg_strdup(setlocale(LC_NUMERIC, NULL), lineno);
-		setlocale(LC_NUMERIC, "C");
+		stmt.oldlocale = ecpg_strdup(SETLOCALE(LC_NUMERIC, NULL), lineno);
+		SETLOCALE(LC_NUMERIC, "C");
 #endif
 
 		/* desperate try to guess something sensible */
@@ -514,7 +516,7 @@ ECPGget_desc(int lineno, const char *desc_name, int index,...)
 #else
 		if (stmt.oldlocale)
 		{
-			setlocale(LC_NUMERIC, stmt.oldlocale);
+			SETLOCALE(LC_NUMERIC, stmt.oldlocale);
 			ecpg_free(stmt.oldlocale);
 		}
 #ifdef HAVE__CONFIGTHREADLOCALE

--- a/src/interfaces/ecpg/ecpglib/execute.c
+++ b/src/interfaces/ecpg/ecpglib/execute.c
@@ -31,6 +31,7 @@
 #include "sqlca.h"
 #include "sqlda-compat.h"
 #include "sqlda-native.h"
+#include "common/mdb_locale.h"
 
 /*
  *	This function returns a newly malloced string that has ' and \
@@ -2002,13 +2003,13 @@ ecpg_do_prologue(int lineno, const int compat, const int force_indicator,
 #ifdef HAVE__CONFIGTHREADLOCALE
 	stmt->oldthreadlocale = _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
 #endif
-	stmt->oldlocale = ecpg_strdup(setlocale(LC_NUMERIC, NULL), lineno);
+	stmt->oldlocale = ecpg_strdup(SETLOCALE(LC_NUMERIC, NULL), lineno);
 	if (stmt->oldlocale == NULL)
 	{
 		ecpg_do_epilogue(stmt);
 		return false;
 	}
-	setlocale(LC_NUMERIC, "C");
+	SETLOCALE(LC_NUMERIC, "C");
 #endif
 
 	/*
@@ -2222,7 +2223,7 @@ ecpg_do_epilogue(struct statement *stmt)
 		uselocale(stmt->oldlocale);
 #else
 	if (stmt->oldlocale)
-		setlocale(LC_NUMERIC, stmt->oldlocale);
+		SETLOCALE(LC_NUMERIC, stmt->oldlocale);
 #ifdef HAVE__CONFIGTHREADLOCALE
 
 	/*

--- a/src/interfaces/libpq/Makefile
+++ b/src/interfaces/libpq/Makefile
@@ -83,7 +83,7 @@ endif
 # that are built correctly for use in a shlib.
 SHLIB_LINK_INTERNAL = -lpgcommon_shlib -lpgport_shlib
 ifneq ($(PORTNAME), win32)
-SHLIB_LINK += $(filter -lcrypt -ldes -lcom_err -lcrypto -lk5crypto -lkrb5 -lgssapi_krb5 -lgss -lgssapi -lssl -lsocket -lnsl -lresolv -lintl -lm, $(LIBS)) $(LDAP_LIBS_FE) $(PTHREAD_LIBS)
+SHLIB_LINK += $(filter -lcrypt -ldes -lcom_err -lcrypto -lk5crypto -lkrb5 -lgssapi_krb5 -lgss -lgssapi -lssl -lsocket -lnsl -lresolv -lintl -lm -lmdblocales, $(LIBS)) $(LDAP_LIBS_FE) $(PTHREAD_LIBS)
 else
 SHLIB_LINK += $(filter -lcrypt -ldes -lcom_err -lcrypto -lk5crypto -lkrb5 -lgssapi32 -lssl -lsocket -lnsl -lresolv -lintl -lm $(PTHREAD_LIBS), $(LIBS)) $(LDAP_LIBS_FE)
 endif

--- a/src/pl/plperl/plperl.c
+++ b/src/pl/plperl/plperl.c
@@ -38,6 +38,7 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "common/mdb_locale.h"
 
 /* define our text domain for translations */
 #undef TEXTDOMAIN
@@ -743,15 +744,15 @@ plperl_init_interp(void)
 			   *save_numeric,
 			   *save_time;
 
-	loc = setlocale(LC_COLLATE, NULL);
+	loc = SETLOCALE(LC_COLLATE, NULL);
 	save_collate = loc ? pstrdup(loc) : NULL;
-	loc = setlocale(LC_CTYPE, NULL);
+	loc = SETLOCALE(LC_CTYPE, NULL);
 	save_ctype = loc ? pstrdup(loc) : NULL;
-	loc = setlocale(LC_MONETARY, NULL);
+	loc = SETLOCALE(LC_MONETARY, NULL);
 	save_monetary = loc ? pstrdup(loc) : NULL;
-	loc = setlocale(LC_NUMERIC, NULL);
+	loc = SETLOCALE(LC_NUMERIC, NULL);
 	save_numeric = loc ? pstrdup(loc) : NULL;
-	loc = setlocale(LC_TIME, NULL);
+	loc = SETLOCALE(LC_TIME, NULL);
 	save_time = loc ? pstrdup(loc) : NULL;
 
 #define PLPERL_RESTORE_LOCALE(name, saved) \
@@ -4167,7 +4168,7 @@ static char *
 setlocale_perl(int category, char *locale)
 {
 	dTHX;
-	char	   *RETVAL = setlocale(category, locale);
+	char	   *RETVAL = SETLOCALE(category, locale);
 
 	if (RETVAL)
 	{
@@ -4182,7 +4183,7 @@ setlocale_perl(int category, char *locale)
 
 #ifdef LC_ALL
 			if (category == LC_ALL)
-				newctype = setlocale(LC_CTYPE, NULL);
+				newctype = SETLOCALE(LC_CTYPE, NULL);
 			else
 #endif
 				newctype = RETVAL;
@@ -4200,7 +4201,7 @@ setlocale_perl(int category, char *locale)
 
 #ifdef LC_ALL
 			if (category == LC_ALL)
-				newcoll = setlocale(LC_COLLATE, NULL);
+				newcoll = SETLOCALE(LC_COLLATE, NULL);
 			else
 #endif
 				newcoll = RETVAL;
@@ -4219,7 +4220,7 @@ setlocale_perl(int category, char *locale)
 
 #ifdef LC_ALL
 			if (category == LC_ALL)
-				newnum = setlocale(LC_NUMERIC, NULL);
+				newnum = SETLOCALE(LC_NUMERIC, NULL);
 			else
 #endif
 				newnum = RETVAL;

--- a/src/port/chklocale.c
+++ b/src/port/chklocale.c
@@ -18,6 +18,8 @@
 #else
 #include "postgres_fe.h"
 #endif
+#include "common/mdb_locale.h"
+
 
 #ifdef HAVE_LANGINFO_H
 #include <langinfo.h>
@@ -343,7 +345,7 @@ pg_get_encoding_from_locale(const char *ctype, bool write_message)
 			pg_strcasecmp(ctype, "POSIX") == 0)
 			return PG_SQL_ASCII;
 
-		save = setlocale(LC_CTYPE, NULL);
+		save = SETLOCALE(LC_CTYPE, NULL);
 		if (!save)
 			return -1;			/* setlocale() broken? */
 		/* must copy result, or it might change after setlocale */
@@ -351,7 +353,7 @@ pg_get_encoding_from_locale(const char *ctype, bool write_message)
 		if (!save)
 			return -1;			/* out of memory; unlikely */
 
-		name = setlocale(LC_CTYPE, ctype);
+		name = SETLOCALE(LC_CTYPE, ctype);
 		if (!name)
 		{
 			free(save);
@@ -366,13 +368,13 @@ pg_get_encoding_from_locale(const char *ctype, bool write_message)
 		sys = win32_langinfo(name);
 #endif
 
-		setlocale(LC_CTYPE, save);
+		SETLOCALE(LC_CTYPE, save);
 		free(save);
 	}
 	else
 	{
 		/* much easier... */
-		ctype = setlocale(LC_CTYPE, NULL);
+		ctype = SETLOCALE(LC_CTYPE, NULL);
 		if (!ctype)
 			return -1;			/* setlocale() broken? */
 

--- a/src/test/locale/test-ctype.c
+++ b/src/test/locale/test-ctype.c
@@ -23,6 +23,8 @@ the author shall be liable for any damage, etc.
 #include <stdio.h>
 #include <locale.h>
 #include <ctype.h>
+#include "common/mdb_locale.h"
+
 
 char	   *flag(int b);
 void		describe_char(int c);
@@ -62,7 +64,7 @@ main()
 	short		c;
 	char	   *cur_locale;
 
-	cur_locale = setlocale(LC_ALL, "");
+	cur_locale = SETLOCALE(LC_ALL, "");
 	if (cur_locale)
 		fprintf(stderr, "Successfully set locale to \"%s\"\n", cur_locale);
 	else

--- a/src/test/regress/output/misc.source
+++ b/src/test/regress/output/misc.source
@@ -609,3 +609,10 @@ CONTEXT:  SQL function "equipment" during startup
 --
 -- rewrite rules
 --
+--- mdb-related
+SELECT mdb_locale_enabled();
+ mdb_locale_enabled 
+--------------------
+ t
+(1 row)
+

--- a/src/test/regress/sql/misc.sql
+++ b/src/test/regress/sql/misc.sql
@@ -55,25 +55,25 @@ DROP TABLE tmp;
 --
 -- copy
 --
-COPY onek TO '@abs_builddir@/results/onek.data';
+COPY onek TO '/home/xifos/git/cloudberry-gpdb/src/test/regress/results/onek.data';
 
 DELETE FROM onek;
 
-COPY onek FROM '@abs_builddir@/results/onek.data';
+COPY onek FROM '/home/xifos/git/cloudberry-gpdb/src/test/regress/results/onek.data';
 
 SELECT unique1 FROM onek WHERE unique1 < 2 ORDER BY unique1;
 
 DELETE FROM onek2;
 
-COPY onek2 FROM '@abs_builddir@/results/onek.data';
+COPY onek2 FROM '/home/xifos/git/cloudberry-gpdb/src/test/regress/results/onek.data';
 
 SELECT unique1 FROM onek2 WHERE unique1 < 2 ORDER BY unique1;
 
-COPY BINARY stud_emp TO '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp TO '/home/xifos/git/cloudberry-gpdb/src/test/regress/results/stud_emp.data';
 
 DELETE FROM stud_emp;
 
-COPY BINARY stud_emp FROM '@abs_builddir@/results/stud_emp.data';
+COPY BINARY stud_emp FROM '/home/xifos/git/cloudberry-gpdb/src/test/regress/results/stud_emp.data';
 
 SELECT * FROM stud_emp;
 


### PR DESCRIPTION
We inherited this issue from PostgreSQL.

PostgreSQL uses glibc to sort strings. In version glibc=2.28, collations broke down badly (in general, there are no guarantees when updating glibc). Changing collations breaks indexes. Similarly, a cluster with different collations also behaves unpredictably.

What and when something has changed in glibc can be found on https://github.com/ardentperf/glibc-unicode-sorting Also there is special postgresql-wiki https://wiki.postgresql.org/wiki/Locale_data_changes And you tube video https://www.youtube.com/watch?v=0E6O-V8Jato

In short, the issue can be seen through the use of bash:

( echo "1-1"; echo "11" ) | LC_COLLATE=en_US.UTF-8 sort

gives the different results in ubunru 18.04 and 22.04.

There is no way to solve the problem other than by not changing the symbol order. We freeze symbol order and use it instead of glibc.

Here the solution https://github.com/postgredients/mdb-locales.

In this PR I have added PostgreSQL patch that replaces all glibc locale-related calls with a calls to an external libary. It activates using new configure parameter --with-mdblocales, which is off by default.

Using custom locales needs libmdblocales1 package and mdb-locales package with symbol table.

Build needs libmdblocales-dev package with headers.

Fixing the symbol order is necessary for OS upgrade. For example Ubuntu 22.04 EOL is April 2027, Rocky 8 Active Support ended May 2024, and Security support ends in 2029.

We use Movable DataBase Locales in Greenplum 6 and all our PostgreSQL installations (starting with PostgreSQL 12). This patch is adopted patch version from our internal PostgreSQL 14 fork.