### PR TITLE
Fix for CDBD expand with concurrent distributed tx (#1801)

### DIFF
--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -493,6 +493,17 @@ redoDistributedCommitRecord(DistributedTransactionId gxid)
 	int			i;
 	bool 			is_hot_standby_qd = IS_HOT_STANDBY_QD();
 
+	/*
+	 * The coordinator may execute write DTX during gpexpand, so the newly
+	 * added segment may contain DTX info in checkpoint XLOG. However, this step
+	 * is useless and should be avoided for segments, or fatal may be thrown since
+	 * max_tm_gxacts is 0 in segments. See also fc8aab88d
+	*/
+	if (ConvertMasterDataDirToSegment && !IS_QUERY_DISPATCHER())
+	{
+		return;
+	}
+
 	/* 
 	 * Only the startup process can be modifying shmNumCommittedGxacts
 	 * and shmCommittedGxidArray. So should be OK reading the value w/o lock.


### PR DESCRIPTION
An duct tape for this was already added as fc8aab8, through redo
path was not patched there. Copy same guard into
redoDistributedCommitRecord function boby.


see also  https://github.com/apache/cloudberry/commit/0fd99be1177f0630fdc26096be9d7a357920de6a