### PR TITLE
Add CONFIGURE_EXTRA_OPTS to use in specific cloud build

### DIFF
--- a/devops/build/automation/cloudberry/scripts/configure-cloudberry.sh
+++ b/devops/build/automation/cloudberry/scripts/configure-cloudberry.sh
@@ -53,6 +53,7 @@
 #
 # Optional Environment Variables:
 #   LOG_DIR - Directory for logs (defaults to ${SRC_DIR}/build-logs)
+#   CONFIGURE_EXTRA_OPTS - Args to pass to configure command
 #   ENABLE_DEBUG - Enable debug build options (true/false, defaults to
 #                  false)
 #
@@ -179,7 +180,8 @@ execute_cmd ./configure --prefix=${BUILD_DESTINATION} \
             --with-uuid=e2fs \
             ${CONFIGURE_MDBLOCALES_OPTS} \
             --with-includes=/usr/local/xerces-c/include \
-            --with-libraries=${BUILD_DESTINATION}/lib || exit 4
+            --with-libraries=${BUILD_DESTINATION}/lib \
+            ${CONFIGURE_EXTRA_OPTS:-""} || exit 4
 log_section_end "Configure"
 
 # Capture version information


### PR DESCRIPTION
Specific option needed to pass parameters to configure script while building on a specific cloud farms