### PR TITLE
Fix flaky privileges regression test: exclude autovacuum worker from backend_type list

### DIFF
--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -2006,7 +2006,8 @@ EXCEPTION WHEN OTHERS THEN
 END$$;
 ALTER FUNCTION terminate_nothrow OWNER TO pg_signal_backend;
 SELECT backend_type FROM pg_stat_activity
-WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END;
+WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END
+  AND backend_type <> 'autovacuum worker';
          backend_type         
 ------------------------------
  autovacuum launcher

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1226,7 +1226,8 @@ EXCEPTION WHEN OTHERS THEN
 END$$;
 ALTER FUNCTION terminate_nothrow OWNER TO pg_signal_backend;
 SELECT backend_type FROM pg_stat_activity
-WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END;
+WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END
+  AND backend_type <> 'autovacuum worker';
 ROLLBACK;
 
 -- test default ACLs


### PR DESCRIPTION
### What does this PR do?

Makes the `privileges` core regression test deterministic. The `terminate_nothrow` / `backend_type` block in `src/test/regress/sql/privileges.sql` pins a fixed list of 4 background processes (`autovacuum launcher`, `dtx recovery process`, `logical replication launcher`, `login monitor`). An `autovacuum worker` can start at any time and add a 5th row, so the test fails intermittently.

The fix excludes the transient `autovacuum worker` from the query so the result no longer depends on autovacuum timing:

```sql
SELECT backend_type FROM pg_stat_activity
WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END
  AND backend_type <> 'autovacuum worker';
```

The expected output stays at the same 4 stable background processes.

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature with breaking changes)
- [ ] Documentation update

### Breaking Changes

None. Only a flaky test's query and its expected output change; no product code is touched.

### Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Passed `make installcheck`
- [ ] Passed `make -C src/test installcheck-cbdb-parallel`

- Affected jobs `ic-good-opt-off` / `ic-deb-good-opt-off` become deterministic: a stray `autovacuum worker` no longer changes the row count.

### Impact

**Performance:**
None.

**User-facing changes:**
None.

**Dependencies:**
None.

### Checklist
- [x] Followed contribution guide
- [ ] Added/updated documentation
- [x] Reviewed code for security implications
- [ ] Requested review from cloudberry committers

### Additional Context

The fixed 4-row expectation was introduced by commit `0612130ff56c6d036b95aa3405828984242827fe` ("Fix failing ic-deb-good-opt-on CI tests: privileges and misc expected outputs"), which matched the output of a single CI run without accounting for the non-deterministic `autovacuum worker`. apache/cloudberry keeps `(0 rows)` here and is not affected; this flakiness is specific to the open-gpdb divergence.
