### PR TITLE
MDB admin counterpatch

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -75,29 +75,27 @@ pg_signal_backend(int pid, int sig, char *msg)
 
 	local_beentry = pgstat_fetch_stat_local_beentry_by_pid(pid);
 
-	/* Only allow superusers to signal superuser-owned backends. */
-	if (superuser_arg(proc->roleId) && !superuser())
+	/*
+	 * Only allow superusers to signal superuser-owned backends.  Any process
+	 * not advertising a role might have the importance of a superuser-owned
+	 * backend, so treat it that way.
+	 */
+	if ((!OidIsValid(proc->roleId) || superuser_arg(proc->roleId)) &&
+		!superuser())
 	{
-		Oid role;
-		char * appname;
+		Oid  role;
+		char *appname;
 
-		if (local_beentry == NULL) {
+		if (local_beentry == NULL)
 			return SIGNAL_BACKEND_NOSUPERUSER;
-		}
 
-		role = get_role_oid("mdb_admin", true /*if nodoby created mdb_admin role in this database*/);
+		role = get_role_oid("mdb_admin", true /* if nobody created mdb_admin role in this database */);
 		appname = local_beentry->backendStatus.st_appname;
 
-		// only allow mdb_admin to kill su queries
-		if (!is_member_of_role(GetUserId(), role)) {
-			return SIGNAL_BACKEND_NOSUPERUSER;
-		}
-
-		if (local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER) {
-			// ok
-		} else if (appname != NULL && strcmp(appname, "MDB") == 0) {
-			// ok
-		} else {
+		if (!(OidIsValid(role) && is_member_of_role(GetUserId(), role) &&
+			 (local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER ||
+			 (appname != NULL && strcmp(appname, "MDB") == 0))))
+		{
 			return SIGNAL_BACKEND_NOSUPERUSER;
 		}
 	}

--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -79,20 +79,25 @@ pg_signal_backend(int pid, int sig, char *msg)
 	 * Only allow superusers to signal superuser-owned backends.  Any process
 	 * not advertising a role might have the importance of a superuser-owned
 	 * backend, so treat it that way.
+	 *
+	 * The mdb_admin role is also allowed to signal autovacuum workers and MDB
+	 * service backends, even though they are superuser-owned.
 	 */
 	if ((!OidIsValid(proc->roleId) || superuser_arg(proc->roleId)) &&
 		!superuser())
 	{
-		Oid  role;
+		Oid	  mdb_admin_role;
 		char *appname;
 
-		if (local_beentry == NULL)
+		if (local_beentry == NULL) {
 			return SIGNAL_BACKEND_NOSUPERUSER;
+		}
 
-		role = get_role_oid("mdb_admin", true /* if nobody created mdb_admin role in this database */);
+		mdb_admin_role = get_role_oid("mdb_admin", true);
 		appname = local_beentry->backendStatus.st_appname;
 
-		if (!(OidIsValid(role) && is_member_of_role(GetUserId(), role) &&
+		if (!(OidIsValid(mdb_admin_role) &&
+			  is_member_of_role(GetUserId(), mdb_admin_role) &&
 			 (local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER ||
 			 (appname != NULL && strcmp(appname, "MDB") == 0))))
 		{

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -2007,13 +2007,9 @@ END$$;
 ALTER FUNCTION terminate_nothrow OWNER TO pg_signal_backend;
 SELECT backend_type FROM pg_stat_activity
 WHERE CASE WHEN COALESCE(usesysid, 10) = 10 THEN terminate_nothrow(pid) END;
-         backend_type         
-------------------------------
- autovacuum launcher
- dtx recovery process
- logical replication launcher
- login monitor
-(4 rows)
+ backend_type 
+--------------
+(0 rows)
 
 ROLLBACK;
 -- test default ACLs


### PR DESCRIPTION
We have CI fail: https://github.com/open-gpdb/cloudberry/actions/runs/30898904670/job/91996120133?pr=50 so we want fix in https://github.com/open-gpdb/cloudberry/commit/b2f60ef5f84 and fix crutch https://github.com/open-gpdb/cloudberry/commit/0612130ff56c6d036b95aa3405828984242827fe, so we're back to where we started https://github.com/open-gpdb/cloudberry/commit/015fa2b17ba

Keep the `mdb_admin` exception narrow, so `pg_signal_backend` alone cannot signal role-less background processes.